### PR TITLE
Unregister gauges on shutdown

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -79,6 +79,18 @@ func (c *exporter) gaugeFromNameAndValue(name string, val float64) error {
 	return nil
 }
 
+// unregisterGauges will remove the gauge metrics so that they do not show
+// incorrect values after the application has been shut down.
+func (c *exporter) unregisterGauges() error {
+	for _, g := range c.gauges {
+		if ok := c.promRegistry.Unregister(g); !ok {
+			return fmt.Errorf("unable to unregister prometheus collector")
+		}
+	}
+
+	return nil
+}
+
 func (c *exporter) metricNameAndLabels(metricName string) (newName string, labels map[string]string, skip bool) {
 	newName, broker, topic := parseMetricName(metricName)
 	if broker == "" && topic == "" {

--- a/saramaprom.go
+++ b/saramaprom.go
@@ -77,6 +77,9 @@ func ExportMetrics(ctx context.Context, metricsRegistry MetricsRegistry, opt Opt
 					opt.OnError(err)
 				}
 			case <-ctx.Done():
+				if err := exp.unregisterGauges(); err != nil {
+					opt.OnError(err)
+				}
 				return
 			}
 		}


### PR DESCRIPTION
Unregister the application on shutdown so the old, now invalid gauge values do not stay in in Prometheus.